### PR TITLE
Update lightsync-games.md

### DIFF
--- a/lightsync-games.md
+++ b/lightsync-games.md
@@ -14,6 +14,7 @@ If you know of a game that has integrated lighting that is not on this list, or 
 > Battlefield V\
 > Beat Cop\
 > Borderlands 3\
+> Borderlands: The Pre-Sequel\
 > Civilization VI\
 > Counter-Strike: Global Offensive\
 > Discord\


### PR DESCRIPTION
Added Borderlands: The Pre-Sequel. The G560 lights are solid purple during gameplay and flash red when the player is shot. It's actually an excellent implementation.